### PR TITLE
should not restart or health check if not installed as service

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -7,3 +7,5 @@
     enabled: yes
     state: restarted
   become: true
+  when: >
+    sb_app_as_a_service != False

--- a/tasks/healthcheck.yml
+++ b/tasks/healthcheck.yml
@@ -11,7 +11,9 @@
   retries: "{{ sb_app_healthcheck_urls_retry_count }}"
   delay: "{{ sb_app_healthcheck_urls_retry_delay }}"
   with_items: "{{ sb_app_healthcheck_urls }}"
-  when: sb_app_healthcheck_urls is defined
+  when: >
+    sb_app_healthcheck_urls is defined and 
+    sb_app_as_a_service != False
 
 - name: "Healthcheck | Wait for {{  sb_app_name }} to be healthy on TCP Ports {{ sb_app_healthcheck_ports }}"
   wait_for:
@@ -19,4 +21,6 @@
     port: "{{ item }}"
     timeout: "{{ sb_app_healthcheck_ports_timeout }}"
   with_items: "{{ sb_app_healthcheck_ports }}"
-  when: sb_app_healthcheck_ports is defined
+  when: >
+    sb_app_healthcheck_ports is defined and 
+    sb_app_as_a_service != False


### PR DESCRIPTION
If I set `sb_app_as_a_service: false` then things fail on trying to start the service. This PR puts a condition to not try to start it or HC it if it isn't installed as a service. The assumption being that if you are not installing as a service then some other mechanism is being used to monitor that the service is up. 